### PR TITLE
Update cmake_minimum_required version to 3.10 in CMakeLists.txt with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cmake"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Add a `dependabot.yml` file to configure Dependabot for updating the `cmake_minimum_required` version.

* **Dependabot Configuration**
  - Specify the version of Dependabot to use.
  - Define the package-ecosystem as `cmake`.
  - Set the directory to the root of the repository.
  - Set the update schedule to daily.
